### PR TITLE
docker start fails

### DIFF
--- a/Nginx/docker-compose.yml
+++ b/Nginx/docker-compose.yml
@@ -13,6 +13,7 @@ services:
 
   iris:
 #   image: store/intersystems/iris:2019.1.0.510.0-community
-    image: intersystemsdc/irishealth-community:2020.4.0.524.0-zpm
+    image: intersystemsdc/irishealth-community
+# :2020.4.0.524.0-zpm
     hostname: iris
 


### PR DESCRIPTION
[INFO] This copy of InterSystems IRIS has been licensed for use exclusively by: Community License expired.